### PR TITLE
Add play services ads lite.

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 16.1.2
+version: 16.1.3
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: Titanium Google Play Services module.

--- a/updater/index.js
+++ b/updater/index.js
@@ -122,7 +122,6 @@ async function gatherLibraries(repository) {
         'play-services-tagmanager',
         'play-services-awareness',
         'play-services-clearcut',
-        'play-services-ads-lite',
         'play-services-phenotype',
         'play-services-vision-image-label',
         'play-services-tagmanager-v4-impl',


### PR DESCRIPTION
`play-services-ads-lite` library is required by ti.admob module.