### PR TITLE
fix: hook compatibility during app build

### DIFF
--- a/android/hooks/libraries.js
+++ b/android/hooks/libraries.js
@@ -6,7 +6,6 @@
 'use strict';
 
 const fork = require('child_process').fork;
-const fs = require('fs-extra');
 const path = require('path');
 
 exports.id = 'ti.playservices.libraries';


### PR DESCRIPTION
The require to `fs-extra` will fail to load the hook during app builds. It's not used anyway so the require can be removed entirely.

```
[WARN]  Bad plugin hooks that failed to load:
[WARN]  /Users/jvennemann/Library/Application Support/Titanium/modules/android/ti.playservices/16.1.3/hooks/libraries.js
[WARN]    Error: Cannot find module 'fs-extra'
[WARN]        at Function.Module._resolveFilename (internal/modules/cjs/loader.js:580:15)
[WARN]        at Function.Module._load (internal/modules/cjs/loader.js:506:25)
[WARN]        at Module.require (internal/modules/cjs/loader.js:636:17)
[WARN]        at require (internal/modules/cjs/helpers.js:20:18)
[WARN]        at Object.<anonymous> (/Users/jvennemann/Library/Application Support/Titanium/modules/android/ti.playservices/16.1.3/hooks/libraries.js:9:12)
[WARN]        at Module._compile (internal/modules/cjs/loader.js:688:30)
[WARN]        at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)
[WARN]        at Module.load (internal/modules/cjs/loader.js:598:32)
[WARN]        at tryModuleLoad (internal/modules/cjs/loader.js:537:12)
[WARN]        at Function.Module._load (internal/modules/cjs/loader.js:529:3)
```

This does not cause any issues during app builds but looks ugly in the build logs.